### PR TITLE
Changes S3 URL to be compatible with all regions

### DIFF
--- a/src/S3RemoteAssetStore.php
+++ b/src/S3RemoteAssetStore.php
@@ -51,8 +51,7 @@ class S3RemoteAssetStore
     public function getURLForKey($key)
     {
         $config = CraftRemoteAssets::getInstance()->getSettings()->s3Config;
-        return 'https://s3-' .
-            $config['region'] .
+        return 'https://s3' .
             '.amazonaws.com/' .
             $config['bucket'] . '/' .
             $config['root'] . '/' .


### PR DESCRIPTION
The US-East-1 region does not support the url https://s3-us-east-1.amazonaws.com/ URL.  This change allows additional regions to use this project.